### PR TITLE
Private Groups Support

### DIFF
--- a/frisky/events.py
+++ b/frisky/events.py
@@ -7,8 +7,8 @@ class MessageEvent(object):
     username: str
     channel_name: str
     text: str
-    command: str
-    args: Tuple[str]
+    command: str = ""
+    args: Tuple[str] = tuple()
 
 
 @dataclass

--- a/frisky/events.py
+++ b/frisky/events.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, Optional
 
 
 @dataclass
 class MessageEvent(object):
     username: str
     channel_name: str
-    text: str
+    text: Optional[str]
     command: str = ""
     args: Tuple[str] = tuple()
 

--- a/plugins/learn.py
+++ b/plugins/learn.py
@@ -29,7 +29,9 @@ class LearnPlugin(FriskyPlugin):
 
     def handle_reaction(self, reaction: ReactionEvent) -> Optional[str]:
         if reaction.emoji == 'brain':
-            return self.create_new_learn(reaction.message.username, reaction.message.text)
+            if reaction.message.text is not None:
+                return self.create_new_learn(reaction.message.username, reaction.message.text)
+            return 'This is a learning-free zone!'
 
     def handle_message(self, message: MessageEvent) -> Optional[str]:
         if message.command in ['learn_count', 'lc']:

--- a/slack/api/models.py
+++ b/slack/api/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 from dataclasses_json import DataClassJsonMixin
 
@@ -118,7 +118,11 @@ class User(BaseModel):
 @dataclass
 class Conversation(BaseModel):
     id: str
-    name: str
+    name: Optional[str] = None
+    is_channel: bool = False
+    is_group: bool = False
+    is_private: bool = False
+    is_im: bool = False
 
 
 @dataclass

--- a/slack/tasks.py
+++ b/slack/tasks.py
@@ -67,13 +67,9 @@ def handle_message_event(event: MessageSent):
 
 
 def handle_reaction_event(event: ReactionAdded):
-    logger.debug(f'Received: {event}')
     user = slack_api_client.get_user(event.user)
-    logger.debug(f'Got user from api: {user}')
     channel = slack_api_client.get_channel(event.item.channel)
-    logger.debug(f'Got channel from api: {channel}')
     item_user = slack_api_client.get_user(event.item_user)
-    logger.debug(f'Got user from api: {item_user}')
     added = event.type == 'reaction_added'
 
     message_text = None

--- a/slack/tasks.py
+++ b/slack/tasks.py
@@ -67,9 +67,13 @@ def handle_message_event(event: MessageSent):
 
 
 def handle_reaction_event(event: ReactionAdded):
+    logger.debug(f'Received: {event}')
     user = slack_api_client.get_user(event.user)
+    logger.debug(f'Got user from api: {user}')
     channel = slack_api_client.get_channel(event.item.channel)
+    logger.debug(f'Got channel from api: {channel}')
     item_user = slack_api_client.get_user(event.item_user)
+    logger.debug(f'Got user from api: {item_user}')
     added = event.type == 'reaction_added'
 
     message_text = None
@@ -77,6 +81,8 @@ def handle_reaction_event(event: ReactionAdded):
         message = slack_api_client.get_message(channel, event.item.ts)
         if message is not None:
             message_text = sanitize_message_text(message.text)
+    else:
+        logger.debug('Did not query api for message, because we are in a private channel')
 
     frisky.handle_reaction(
         ReactionEvent(
@@ -87,8 +93,6 @@ def handle_reaction_event(event: ReactionAdded):
                 username=item_user.get_short_name(),
                 channel_name=channel.name,
                 text=message_text,
-                command='',
-                args=tuple(),
             ),
         ),
         reply_channel=lambda reply: slack_api_client.post_message(channel, reply)

--- a/slack/tasks.py
+++ b/slack/tasks.py
@@ -50,23 +50,18 @@ def reply_channel(conversation: Conversation, response: FriskyResponse) -> bool:
 
 
 def handle_message_event(event: MessageSent):
-    user = slack_api_client.get_user(event.user)
-    if event.channel_type == 'im':
-        # TODO: Is there an api method (or a reason) to look this up?
-        channel = Conversation(id=event.channel, name=user.name)
-    elif event.channel_type in ('channel', 'group'):
-        channel = slack_api_client.get_channel(event.channel)
-    else:
+    if not event.text.startswith(settings.FRISKY_PREFIX):
         return
-    message_event = MessageEvent(
-        username=user.get_short_name(),
-        channel_name=channel.name,
-        text=sanitize_message_text(event.text),
-        command='',
-        args=tuple(),
-    )
+
+    user = slack_api_client.get_user(event.user)
+    channel = slack_api_client.get_channel(event.channel)
+
     frisky.handle_message(
-        message_event,
+        MessageEvent(
+            username=user.get_short_name(),
+            channel_name=channel.name,
+            text=sanitize_message_text(event.text),
+        ),
         reply_channel=lambda reply: reply_channel(channel, reply)
     )
 
@@ -76,8 +71,12 @@ def handle_reaction_event(event: ReactionAdded):
     channel = slack_api_client.get_channel(event.item.channel)
     item_user = slack_api_client.get_user(event.item_user)
     added = event.type == 'reaction_added'
-    message = slack_api_client.get_message(channel, event.item.ts)
-    message_text = sanitize_message_text(message.text if message is not None else "")
+
+    message_text = None
+    if not channel.is_private:
+        message = slack_api_client.get_message(channel, event.item.ts)
+        if message is not None:
+            message_text = sanitize_message_text(message.text)
 
     frisky.handle_reaction(
         ReactionEvent(

--- a/slack/tasks.py
+++ b/slack/tasks.py
@@ -54,7 +54,7 @@ def handle_message_event(event: MessageSent):
     if event.channel_type == 'im':
         # TODO: Is there an api method (or a reason) to look this up?
         channel = Conversation(id=event.channel, name=user.name)
-    elif event.channel_type == 'channel':
+    elif event.channel_type in ('channel', 'group'):
         channel = slack_api_client.get_channel(event.channel)
     else:
         return

--- a/slack/test_data.py
+++ b/slack/test_data.py
@@ -189,3 +189,47 @@ message_deleted_event = '''{
 }'''
 
 complete_and_utter_rubbish = '''{"msg": "just some rubbish for test coverage"}'''
+
+dm_json = '''{
+        "id": "D00000000",
+        "created": 1582815028,
+        "is_archived": false,
+        "is_im": true,
+        "is_org_shared": false,
+        "user": "U00000000",
+        "last_read": "0000000000.000000",
+        "latest": {
+            "bot_id": "B00000000",
+            "type": "message",
+            "text": "pong",
+            "user": "U00000000",
+            "ts": "1582815032.000300",
+            "team": "T00000000",
+            "bot_profile": {
+                "id": "B00000000",
+                "deleted": false,
+                "name": "Risky",
+                "updated": 1581702916,
+                "app_id": "A00000000",
+                "icons": {
+                    "image_36": "https://avatars.slack-edge.com/2020-02-14/952745718468_58cea6ae8be276fc1f1e_36.png",
+                    "image_48": "https://avatars.slack-edge.com/2020-02-14/952745718468_58cea6ae8be276fc1f1e_48.png",
+                    "image_72": "https://avatars.slack-edge.com/2020-02-14/952745718468_58cea6ae8be276fc1f1e_72.png"
+                },
+                "team_id": "T00000000"
+            },
+            "reactions": [
+                {
+                    "name": "upvote",
+                    "users": [
+                        "U00000000"
+                    ],
+                    "count": 1
+                }
+            ]
+        },
+        "unread_count": 2,
+        "unread_count_display": 1,
+        "is_open": false,
+        "priority": 0
+    }'''

--- a/slack/test_tasks.py
+++ b/slack/test_tasks.py
@@ -89,7 +89,7 @@ class EventHandlingTestCase(TestCase):
         expected = MessageEvent(
             username='spengler',
             channel_name='general',
-            text='I like to :poop:',
+            text='?I like to :poop:',
             command='',
             args=tuple()
         )
@@ -110,7 +110,7 @@ class EventHandlingTestCase(TestCase):
                 handle_message_event(MessageSent(
                     channel='123',
                     user='W012A3CDE',
-                    text='I like to :poop:',
+                    text='?I like to :poop:',
                     ts='123',
                     event_ts='123',
                     channel_type='channel'

--- a/slack/tests.py
+++ b/slack/tests.py
@@ -114,4 +114,8 @@ class SlackApiModelsTestCase(TestCase):
         convo = Conversation.create(None)
         self.assertIsNone(convo)
 
-
+    def test_dm_deserialization(self):
+        convo = Conversation.from_json(dm_json)
+        self.assertIsNotNone(convo)
+        self.assertIsNone(convo.name)
+        self.assertTrue(convo.is_im)


### PR DESCRIPTION
### What is this change?

QOL changes for using Frisky in a private chat. Most notably, Learns don't work. This is enforced at the bot level, plugins won't receive message texts unless it begins with the prefix character

### Why are you making this change?

Frisky has half broken private chat support just incidentally, this will formalize it

### How have you tested this change?

Deploying to Risky as aI type