### PR TITLE
move help into plugin, now that PluginRepositoryMixin exists

### DIFF
--- a/frisky/bot.py
+++ b/frisky/bot.py
@@ -72,31 +72,11 @@ class Frisky(object):
         message.command = '*'
         return message
 
-    def __show_help_text(self, args: List[str], reply_channel: Callable[[str], bool]) -> None:
-        if len(args) == 1:
-            plugin_name = args[0]
-            if plugin_name == 'help':
-                reply_channel('Usage: `?help` or `?help <plugin_name>`')
-                return
-            plugin = self.__loaded_plugins.get(plugin_name, None)
-            if plugin is None:
-                reply_channel(f'No such plugin: `{plugin_name}`, try `?help` to list installed plugins')
-            elif (help_text := plugin.help_text()) is None:
-                reply_channel(f'Plugin `{plugin_name}` does not provide help text.')
-            else:
-                reply_channel(help_text)
-        else:
-            plugins = self.__loaded_plugins.keys()
-            joined_string = ', '.join(plugins)
-            reply_channel(f'Available plugins: {joined_string}')
-
     def handle_message(self, message: MessageEvent, reply_channel: Callable[[FriskyResponse], bool]) -> None:
         if message.channel_name in self.ignored_channels or message.username == self.name:
             return
         message.command, message.args = self.parse_message_string(message.text)
-        if message.command in ('help', '?'):
-            return self.__show_help_text(message.args, reply_channel)
-        elif message.command != '':
+        if message.command != '':
             plugins = self.get_plugins_for_command(message.command)
             if len(plugins) == 0:
                 # Reformat the message as a generic one

--- a/frisky/plugin.py
+++ b/frisky/plugin.py
@@ -75,7 +75,7 @@ class PluginRepositoryMixin(object):
     loaded_plugins: Dict[str, FriskyPlugin]
 
     def get_plugin_by_name(self, name: str) -> Optional[FriskyPlugin]:
-        return self.loaded_plugins[name]
+        return self.loaded_plugins.get(name, None)
 
     def get_plugin_for_command(self, command: str) -> Optional[FriskyPlugin]:
         for plugin in self.loaded_plugins.values():

--- a/frisky/plugin.py
+++ b/frisky/plugin.py
@@ -74,6 +74,9 @@ class FriskyPlugin(object):
 class PluginRepositoryMixin(object):
     loaded_plugins: Dict[str, FriskyPlugin]
 
+    def get_plugin_names(self):
+        return self.loaded_plugins.keys()
+
     def get_plugin_by_name(self, name: str) -> Optional[FriskyPlugin]:
         return self.loaded_plugins.get(name, None)
 

--- a/plugins/help.py
+++ b/plugins/help.py
@@ -19,11 +19,9 @@ class HelpPlugin(FriskyPlugin, PluginRepositoryMixin):
             plugin = self.get_plugin_by_name(plugin_name)
             if plugin is None:
                 return f'No such plugin: `{plugin_name}`, try `?help` to list installed plugins'
-            elif (help_text := plugin.help_text()) is None:
+            if (help_text := plugin.help_text()) is None:
                 return f'Plugin `{plugin_name}` does not provide help text.'
-            else:
-                return help_text
-        else:
-            plugins = self.loaded_plugins.keys()
-            joined_string = ', '.join(plugins)
-            return f'Available plugins: {joined_string}'
+            return help_text
+        plugins = self.get_plugin_names()
+        joined_string = ', '.join(plugins)
+        return f'Available plugins: {joined_string}'

--- a/plugins/help.py
+++ b/plugins/help.py
@@ -1,0 +1,29 @@
+from typing import Tuple
+
+from frisky.events import MessageEvent
+from frisky.plugin import FriskyPlugin, PluginRepositoryMixin
+from frisky.responses import FriskyResponse
+
+
+class HelpPlugin(FriskyPlugin, PluginRepositoryMixin):
+
+    @classmethod
+    def register_commands(cls) -> Tuple:
+        return 'help', '?'
+
+    def handle_message(self, message: MessageEvent) -> FriskyResponse:
+        if len(message.args) == 1:
+            plugin_name = message.args[0]
+            if plugin_name == 'help':
+                return 'Usage: `?help` or `?help <plugin_name>`'
+            plugin = self.get_plugin_by_name(plugin_name)
+            if plugin is None:
+                return f'No such plugin: `{plugin_name}`, try `?help` to list installed plugins'
+            elif (help_text := plugin.help_text()) is None:
+                return f'Plugin `{plugin_name}` does not provide help text.'
+            else:
+                return help_text
+        else:
+            plugins = self.loaded_plugins.keys()
+            joined_string = ', '.join(plugins)
+            return f'Available plugins: {joined_string}'


### PR DESCRIPTION
### What is this change?

Move help functionality out of bot.py

### Why are you making this change?

It's really outside the core functionality of the bot, and was only in there because at the time, plugins couldn't query other plugins. This is changed with PluginRepositoryMixin

### How have you tested this change?

Tests pass