### PR TITLE
Plugin API V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,14 @@ function to do implement any functionality.
 This example is included in the source as `ping.py`
 
 ```python
-from typing import Tuple, Optional
-
 from frisky.plugin import FriskyPlugin
 
 
 class PingPlugin(FriskyPlugin):
+    
+    commands = ['ping']
 
-    def register_commands(self) -> Tuple:
-        return 'ping',
-
-    def handle_message(self, message) -> Optional[str]:
+    def command_ping(self, message):
         return 'pong'
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,21 +21,20 @@ end-to-end. However, a test case class is provided to more easily test simple pl
 To create a plugin, add a python file underneath the `plugins/` directory. Inside this file, import and extend the base
 frisky plugin `frisky.plugins.FriskyPlugin`.  This class contains the base functionality you'll need for a new plugin.
 
-Additionally you'll notice several unimplemented functions:
+To implement your plugin, implement any of the following properties and methods:
 
-* `register_emoji(cls)` - this no argument class method should define the emoji your plugin will react to, if any
-* `register_commands(cls)` - this no argument class method should define the commands your plugin will react to, if any
-* `help_text(cls)` - this no argument class method should return helpful information about how to use your plugin in 
-   slack
-* `handle_message(self, message)` - this method implements handling a message, ie one of the 'commands' you registered
-   in the `register_commands` class method above. The `message` argument is a MessageEvent from the `frisky.events`
-   package and should contain basic information (slack channel, raw command text sent, user name of sender, etc ...)
-* `handle_reaction(self, reaction)` - this method implements handling a reaction, ie one of the 'emoji' you registered
-   in the `register_emoji` class method above.  The `message` argument is a `ReactionEvent` from the `frisky.events`
-   package and should contain basic information (emoji string, username of the user who received the emoji) as well as 
-   a `MessageEvent` instance.            
+* `reactions: List[str]` - a list of emoji reactions you want to handle
+* `commands: List[str]` - a list of commands you want to handle
+* `help: str` - helpful information about how to use your plugin in slack
+* `command_aliases: Dict[str, str]` - a dictionary in order to alias commands to others (see learn.py for an example)
+* `def command_{command_name}(self, message)` - for each command you want to handle in your plugin. The `message`
+   argument is a MessageEvent from the `frisky.events` package and should contain basic information (slack channel, raw
+   command text sent, user name of sender, etc ...)
+* `def reaction_{emoji}(self, reaction)` - for each reaction you want to handle in your plugin. The `message` argument
+   is a `ReactionEvent` from the `frisky.events` package and should contain basic information (emoji string, username of
+   the user who received the emoji) as well as a `MessageEvent` instance.            
 
-Note that all 'register' methods are optional, however you must at least implement one and it's corresponding handler
+Note that all of these properties are optional, however you must at least implement one and it's corresponding handler
 function to do implement any functionality.                  
 
 ### An example plugin

--- a/learns/queries.py
+++ b/learns/queries.py
@@ -30,6 +30,8 @@ def get_learn_indexed(label: str, index: int):
 def get_random_learn():
     all_learns = Learn.objects.all()
     count = all_learns.aggregate(count=Count('id'))['count']
+    if count == 0:
+        return None
     random_index = randint(0, count - 1)
     return all_learns[random_index]
 

--- a/plugins/ping.py
+++ b/plugins/ping.py
@@ -1,13 +1,10 @@
-from typing import Tuple, Optional
+from typing import Optional
 
 from frisky.plugin import FriskyPlugin
 
 
 class PingPlugin(FriskyPlugin):
+    commands = ['ping']
 
-    @classmethod
-    def register_commands(cls) -> Tuple:
-        return 'ping',
-
-    def handle_message(self, message) -> Optional[str]:
+    def command_ping(self, message) -> Optional[str]:
         return 'pong'

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -1,0 +1,34 @@
+from django.test import TestCase
+
+from frisky.events import MessageEvent, ReactionEvent
+from frisky.plugin import FriskyPlugin
+
+
+class BasePluginTestCase(TestCase):
+
+    def setUp(self) -> None:
+        self.plugin = FriskyPlugin()
+
+    def test_unhandled_command_returns_none(self):
+        message_event = MessageEvent(
+            username='testuser',
+            channel_name='general',
+            text='?hello world'
+        )
+        response = self.plugin.handle_message(message_event)
+        self.assertIsNone(response)
+
+    def test_unhandled_reaction_returns_none(self):
+        message_event = MessageEvent(
+            username='testuser',
+            channel_name='general',
+            text='?hello world'
+        )
+        reaction_event = ReactionEvent(
+            emoji='bacon',
+            username='testuser2',
+            added=True,
+            message=message_event
+        )
+        response = self.plugin.handle_reaction(reaction_event)
+        self.assertIsNone(response)

--- a/tests/test_learn.py
+++ b/tests/test_learn.py
@@ -30,6 +30,10 @@ class LearnTestCase(FriskyTestCase):
     def test_reaction_learn(self):
         self.assertEqual(self.send_reaction('brain', 'jim', 'jarjar'), 'Okay, learned jarjar')
 
+    def test_learn_free_zone(self):
+        self.assertEqual(self.send_reaction('brain', 'george', 'john', reacted_message=None),
+                         'This is a learning-free zone!')
+
     def test_get_nonexistant_learn(self):
         self.assertRaises(ValueError, lambda: get_random_learn_for_label('xyzzy'))
 
@@ -99,6 +103,9 @@ class LearnTestCase(FriskyTestCase):
         patcher.start()
         self.assertEqual(self.send_message('?random'), 'test_2: thing2')
         patcher.stop()
+
+    def test_get_random_no_learns_returns_none(self):
+        self.assertIsNone(self.send_message('?random'))
 
     def test_no_such_thing(self):
         self.send_message('?learn test_1 thing1')


### PR DESCRIPTION
### What is this change?

Introduce a new, backwards compatible, API for writing plugins. See the README for specifics

### Why are you making this change?

to make plugin development easier and plugin code cleaner. Nothing has changed at the bot level, and the base implementations of the old functions now call out to the new properties.

### How have you tested this change?

All automated tests still pass