### PR TITLE
Strip < and > from Slack formatted URLs, and add headers to api calls

### DIFF
--- a/frisky/plugin.py
+++ b/frisky/plugin.py
@@ -95,7 +95,14 @@ class FriskyApiPlugin(FriskyPlugin):
 
     @staticmethod
     def do_api_call(http: FriskyPlugin.HttpWrapper, url: str, element: Optional[str] = None) -> FriskyResponse:
-        response = http.get(url)
+        headers = {
+            'User-Agent': 'Frisky (https://github.com/zachtib/Frisky)',
+        }
+        if element is None:
+            headers['Accept'] = 'text/plain'
+        else:
+            headers['Accept'] = 'application/json'
+        response = http.get(url, headers=headers)
         if response.status_code != 200:
             return
         if element is None:

--- a/plugins/apilearn.py
+++ b/plugins/apilearn.py
@@ -23,6 +23,7 @@ class ApiLearnPlugin(FriskyPlugin):
             element = message.args[2]
         else:
             return None
+        url = url.removeprefix('<').removesuffix('>')
         ApiLearn.objects.create(label=label, url=url, element=element)
         return f'OK, learned {label}'
 


### PR DESCRIPTION
### What is this change?



### Why are you making this change?



### How have you tested this change?
